### PR TITLE
make the browser script optional, minor fix to tv shows activity view, a...

### DIFF
--- a/browser.sh
+++ b/browser.sh
@@ -19,11 +19,7 @@ fi
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ $# -eq 2 ]; then
-	url="https://www.netflix.com/SwitchProfile?tkn=$2&nextpage=https%3A%2F%2Fwww.netflix.com%2FWiPlayer%3Fmovieid%3D$1"
-else
-	url="http://www.netflix.com/WiPlayer?movieid=$1"
-fi
+url=$1
 
 # notice the ampersand to send google chrome into back ground so that the script continues and we execute the xdotool below
 /usr/bin/google-chrome --start-maximized --disable-translate --disable-new-tab-first-run --no-default-browser-check --no-first-run --kiosk "$url" &

--- a/default.py
+++ b/default.py
@@ -68,6 +68,9 @@ viewIdActivity = addon.getSetting("viewIdActivity")
 winBrowser = int(addon.getSetting("winBrowserNew"))
 language = addon.getSetting("language")
 auth = addon.getSetting("auth")
+linuxUseShellScript = addon.getSetting("linuxUseShellScript") == "true"
+debug = addon.getSetting("debug") == "true"
+
 if len(language.split("-"))>1:
     country = language.split("-")[1]
 
@@ -91,6 +94,9 @@ def newSession():
 session = newSession()
 
 def load(url, post = None):
+    if debug:
+        print "URL: " + url
+
     r = ""
     try:
         if post:
@@ -464,7 +470,9 @@ def listViewingActivity(type):
         title = date+" - "+title
         if videoID not in videoIDs:
             videoIDs.append(videoID)
-            added = listVideo(videoID, title, "", False, False, type)
+            # due to limitations in the netflix api, there is no way to get the seriesId of an
+            # episode, so the 4 param is set to True to treat tv episodes the same as movies.
+            added = listVideo(videoID, title, "", True, False, type)
             if added:
                 count += 1
             if count == 40:
@@ -497,7 +505,6 @@ def getSeriesInfo(seriesID):
         content = fh.read()
         fh.close()
     if not content:
-        #url = "http://api-global.netflix.com/desktop/odp/episodes?languages="+language+"&forceEpisodes=true&routing=redirect&seriesId="+seriesID+"&country="+country
         url = "http://api-global.netflix.com/desktop/odp/episodes?languages="+language+"&forceEpisodes=true&routing=redirect&video="+seriesID+"&country="+country
         content = load(url)
         fh = xbmcvfs.File(cacheFile, 'w')
@@ -569,10 +576,10 @@ def playVideo(id):
 
 def playVideoMain(id):
     xbmc.Player().stop()
-    token = ""
     if singleProfile:
         url = urlMain+"/WiPlayer?movieid="+id
     else:
+        token = ""
         if addon.getSetting("profile"):
             token = addon.getSetting("profile")
         url = "https://www.netflix.com/SwitchProfile?tkn="+token+"&nextpage="+urllib.quote_plus(urlMain+"/WiPlayer?movieid="+id)
@@ -594,16 +601,26 @@ def playVideoMain(id):
         except:
             pass
     elif osLinux:
-        xbmc.executebuiltin('LIRC.Stop')
-        
-        if token != "":
-            call = '"'+browserScript+'" "'+id+'" "'+token+'"';
+        if linuxUseShellScript:
+            xbmc.executebuiltin('LIRC.Stop')
+            
+            call = '"'+browserScript+'" "'+url+'"';
+            if debug:
+                print "Browser Call: " + call
+            subprocess.call(call, shell=True)
+            
+            xbmc.executebuiltin('LIRC.Start')
         else:
-            call = '"'+browserScript+'" "'+id+'"';
-        
-        subprocess.call(call, shell=True)
-         
-        xbmc.executebuiltin('LIRC.Start')
+            xbmc.executebuiltin("RunPlugin(plugin://plugin.program.chrome.launcher/?url="+urllib.quote_plus(url)+"&mode=showSite&kiosk="+kiosk+")")
+            try:
+                xbmc.sleep(5000)
+                subprocess.Popen('xdotool mousemove 9999 9999', shell=True)
+                xbmc.sleep(5000)
+                subprocess.Popen('xdotool mousemove 9999 9999', shell=True)
+                xbmc.sleep(5000)
+                subprocess.Popen('xdotool mousemove 9999 9999', shell=True)
+            except:
+                pass
     elif osWin:
         if winBrowser == 1:
             path = 'C:\\Program Files\\Internet Explorer\\iexplore.exe'

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -56,4 +56,6 @@
   <string id="30202">General</string>
   <string id="30203">Views</string>
   <string id="30204">Advanced</string>
+  <string id="30205">Debug</string>
+  <string id="30206">Linux: Use Shell Script</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -16,12 +16,15 @@
         <setting id="viewIdActivity" type="number" label="30130" enable="eq(-3,true)" default="51"/>
     </category>
     <category label="30204">
+    	<setting id="debug" type="bool" label="30205" default="false"/>
+    	
         <setting id="libraryPath" type="folder" label="30138" default="special://profile/addon_data/plugin.video.netflixbmc/library"/>
         <setting id="useUtility" type="bool" label="30107" default="true"/>
         <setting label="30116" type="action" enable="eq(-1,true)" action="RunPlugin(plugin://plugin.video.netflixbmc/?mode=configureUtility)"/>
         <setting id="remoteControl" type="bool" label="30137" default="false"/>
         <setting id="dontUseKiosk" type="bool" label="30133" default="false"/>
         <setting id="winBrowserNew" type="enum" label="30104" values="Chrome|IExplorer" default="0"/>
+        <setting id="linuxUseShellScript" type="bool" label="30206" default="false"/>
         <setting type="sep" />
         <setting label="30132" type="action" action="RunPlugin(plugin://plugin.video.netflixbmc/?mode=deleteCache)"/>
         <setting label="30125" type="action" action="RunPlugin(plugin://plugin.video.netflixbmc/?mode=deleteCookies)"/>


### PR DESCRIPTION
Added debug mode, just to print the URL's at this stage.

Cleaned up the linux support, so that the default is to use the chrome launcher, but can use the browser.sh if the new config entry is selected.

Properly fixed the activity view for TV shows.  The api no longer provides access to get the series movie id.  So changed the listing so that if you click on a tv show in activity view it will launch that episode, rather than try and list the whole series.
