### PR TITLE
Do not send xdotool key commands to Chrome window

### DIFF
--- a/default.py
+++ b/default.py
@@ -1225,13 +1225,13 @@ class window(xbmcgui.WindowXMLDialog):
             elif debug:
                 print "Netflixbmc: unmapped key action=%d" % (action.getId())
             if key is not None:
-                p = subprocess.Popen('xdotool search --onlyvisible --class "google-chrome|Chromium" key %s' % key, shell=True)
+                if debug:
+                    print "Netflixbmc: remote action=%d key=%s xdotool result=%d" % (action.getId(), key, p.returncode)
+                p = subprocess.Popen('xdotool key %s' % key, shell=True)
                 p.wait()
                 # 0 for success, 127 if xdotool not found in PATH. Return code is 1 if window not found (indicating should close).
                 if not p.returncode in [0,127] or doClose:
                     self.close()
-                if debug:
-                    print "Netflixbmc: remote action=%d key=%s xdotool result=%d" % (action.getId(), key, p.returncode)
         elif osOSX:
             proc = subprocess.Popen('/bin/ps ax', shell=True, stdout=subprocess.PIPE)
             procAll = ""


### PR DESCRIPTION
TLDR: This pull request fixes closing the Chrome window in the plugin on Linux, allowing remotes to close the browser window without pulling out a keyboard or doing any other finagling.

Having xdotool send keystrokes directly to the Chrome window bypasses the window manager, which means the alt-f4 shortcut won't be received by it, and the window doesn't close. So I stopped searching for the Chrome window. This gives the WM a chance to intercept alt-f4 and do its window closing thing, and all other keystrokes will be passed through to the foreground window (hopefully Chrome).

I've tested this on a Debian Unstable machine with the following environments:
* GNOME 3.14
* fluxbox 1.3.5
* openbox 3.5.2

All behaved as expected, with no change to netflix shortcuts (I tested volume control and forward/backward seeking), and hitting the back button on my yatse remote caused the browser to exit and the plugin cleaned up gracefully.

Bonus change, moving the debug log above the sys.exit(), so we still get logging when the script exits.

If this approach is deemed too risky, I'd be willing to test replacing it with Ctrl-Shift-Q, which is the Chrome shortcut for exiting the application, according to https://support.google.com/chrome/answer/157179?hl=en