### PR TITLE
Listed but not yet released episodes

### DIFF
--- a/default.py
+++ b/default.py
@@ -493,7 +493,7 @@ def listEpisodes(seriesID, season):
                 duration = item["runtime"]
                 bookmarkPosition = item["bookmarkPosition"]
                 playcount=0
-                if (float(bookmarkPosition)/float(duration))>=0.9:
+                if (duration>0 and float(bookmarkPosition)/float(duration))>=0.9:
                     playcount=1
                 desc = item["synopsis"].encode('utf-8')
                 try:


### PR DESCRIPTION
Some series (like Orphan Black atm) have a new episode released each week. The listing returns all episodes in the season. Not yet released episodes return a duration of zero.