### PR TITLE
Linux: Change remote close sequence to Ctrl-Shift-Q from Alt-F4

### DIFF
--- a/default.py
+++ b/default.py
@@ -1225,7 +1225,7 @@ class window(xbmcgui.WindowXMLDialog):
             doClose = False
             key=None
             if action in [ACTION_SHOW_GUI, ACTION_STOP, ACTION_PARENT_DIR, ACTION_PREVIOUS_MENU, KEY_BUTTON_BACK]:
-                key="alt+F4"
+                key="control+shift+q"
                 doClose=True
             elif action in [ ACTION_SELECT_ITEM, ACTION_PLAYER_PLAY, ACTION_PAUSE ]:
                 key="space"


### PR DESCRIPTION
Alt-F4 has problems with some Windows managers, as per #40. Ctrl-Shift-Q is processed directly by Chrome.

(This PR is based on the discussion in #40. Tested with openbox & Chrome 42.)