### PR TITLE
Add the ability to launch the Netflix app on android

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,14 +3,14 @@
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.requests" version="2.4.3"/>
-        <import addon="plugin.program.chrome.launcher" version="1.1.2"/>
+        <import addon="plugin.program.chrome.launcher" version="1.1.2" optional="true"/>
         <import addon="script.module.pydevd" version="2.1.0" optional="true"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>
     </extension>
     <extension point="xbmc.addon.metadata">
-        <platform>windx osx linux</platform>
+        <platform>windx osx linux android</platform>
         <summary lang="en">NetfliXBMC - Unofficial Netflix Add-on (Win/OSX/Linux)</summary>
         <language></language>
         <description lang="en">NetfliXBMC - Unofficial Netflix Add-on (Win/OSX/Linux)</description>

--- a/default.py
+++ b/default.py
@@ -881,7 +881,7 @@ def login():
         return True
     else:
         xbmc.executebuiltin('XBMC.Notification(NetfliXBMC:,'+str(translation(30126))+',10000,'+icon+')')
-        if debuginProgress:
+        if loginProgress:
             loginProgress.close()
         return False
 

--- a/default.py
+++ b/default.py
@@ -720,8 +720,6 @@ def playVideoMain(id):
             #xbmc.executebuiltin("RunPlugin(plugin://plugin.program.chrome.launcher/?url="+urllib.quote_plus(url)+"&mode=showSite&kiosk="+kiosk+")")
         if useUtility:
             subprocess.Popen('"'+utilityPath+'"', shell=False)
-    elif osAndroid:
-        xbmc.executebuiltin('XBMC.StartAndroidActivity("com.android.browser","","","' + url + '")')
 
     myWindow = window('window.xml', addon.getAddonInfo('path'), 'default',)
     myWindow.doModal()
@@ -1288,7 +1286,7 @@ class window(xbmcgui.WindowXMLDialog):
             else:
                 self.close()
         elif osAndroid:
-            pass #I don't know if we can do this on android
+            pass #I don't know if we can do this on android, We also may not need to as the netflix app should respond to remotes
 
 
 params = parameters_string_to_dict(sys.argv[2])

--- a/default.py
+++ b/default.py
@@ -684,6 +684,8 @@ def playVideoMain(id):
             subprocess.Popen('cliclick kp:arrow-up', shell=True)
         except:
             pass
+    elif osAndroid:
+        xbmc.executebuiltin('XBMC.StartAndroidActivity("","android.intent.action.VIEW","","' + urlMain+'/watch/' + id + '")')
     elif osLinux:
         if linuxUseShellScript:
             xbmc.executebuiltin('LIRC.Stop')
@@ -881,7 +883,7 @@ def login():
         return True
     else:
         xbmc.executebuiltin('XBMC.Notification(NetfliXBMC:,'+str(translation(30126))+',10000,'+icon+')')
-        if loginProgress:
+        if debuginProgress:
             loginProgress.close()
         return False
 

--- a/default.py
+++ b/default.py
@@ -66,6 +66,7 @@ addonID = addon.getAddonInfo('id')
 osWin = xbmc.getCondVisibility('system.platform.windows')
 osLinux = xbmc.getCondVisibility('system.platform.linux')
 osOSX = xbmc.getCondVisibility('system.platform.osx')
+osAndroid = xbmc.getCondVisibility('system.platform.android')
 addonDir = xbmc.translatePath(addon.getAddonInfo('path'))
 defaultFanart = os.path.join(addonDir ,'fanart.png')
 addonUserDataFolder = xbmc.translatePath("special://profile/addon_data/"+addonID)
@@ -717,6 +718,8 @@ def playVideoMain(id):
             #xbmc.executebuiltin("RunPlugin(plugin://plugin.program.chrome.launcher/?url="+urllib.quote_plus(url)+"&mode=showSite&kiosk="+kiosk+")")
         if useUtility:
             subprocess.Popen('"'+utilityPath+'"', shell=False)
+    elif osAndroid:
+        xbmc.executebuiltin('XBMC.StartAndroidActivity("com.android.browser","","","' + url + '")')
 
     myWindow = window('window.xml', addon.getAddonInfo('path'), 'default',)
     myWindow.doModal()
@@ -1282,6 +1285,8 @@ class window(xbmcgui.WindowXMLDialog):
                     subprocess.Popen('cliclick kp:arrow-down', shell=True)
             else:
                 self.close()
+        elif osAndroid:
+            pass #I don't know if we can do this on android
 
 
 params = parameters_string_to_dict(sys.argv[2])


### PR DESCRIPTION
This adds the ability to launch the netflix app via android intents, resulting in a similar experience as you get on windows. to get back to Kodi you just need to hit the back button.