### PR TITLE
Feature/video info using title page

### DIFF
--- a/resources/lib/netflix.py
+++ b/resources/lib/netflix.py
@@ -6,7 +6,7 @@ class urls:
     home              = netflix+"/WiHome"
     login             = netflix+"/Login"
     # mylist            = netflix+"/MyList?leid=595&link=seeall"
-    mylist            = netflix+"browse/my-list"
+    mylist            = netflix+"/browse/my-list"
     recent            = netflix+"/WiRecentAdditionsGallery?nRR=releaseDate&nRT=all&pn=1&np=1&actionMethod=json"
     genre             = netflix+"/WiGenre?agid={agid}"
     activity          = netflix+"/WiViewingActivity"

--- a/resources/lib/netflix.py
+++ b/resources/lib/netflix.py
@@ -10,7 +10,7 @@ class urls:
     recent            = netflix+"/WiRecentAdditionsGallery?nRR=releaseDate&nRT=all&pn=1&np=1&actionMethod=json"
     genre             = netflix+"/WiGenre?agid={agid}"
     activity          = netflix+"/WiViewingActivity"
-    video_info        = netflix+"/JSON/BOB?movieid={movieid}"
+    video_info        = netflix+"/title/{movieid}"
     video_play        = netflix+"/WiPlayer?movieid={movieid}"
     add_to_queue      = netflix+"/AddToQueue?movieid={movieid}&qtype=INSTANT&{encodedAuth}"
     remove_from_queue = netflix+"/QueueDelete?{encodedAuth}&qtype=ED&movieid={movieid}"


### PR DESCRIPTION
Changed getVideoInfo to use the title page (`www.netflix.com/title/{videoID}`) as the old video info page was just redirecting to the main screen. 

I also replaced the regular expression parser in list_video with an `lxml` XPath parser - its more sane that way and less breaky. 

There are some readers there which I couldn't get right - the MPAA rating is gone, instead they have something called "maturity rating", so I used that instead; and I couldn't find where the quality rating is on the website at all.

I've tested it and more things work now, especially in the "my list" TV Shows section, but there is still work to be done: search, for example, sometimes still fails with an error parsing, and even if it doesn't - the list is empty.
